### PR TITLE
Add NewDestination function

### DIFF
--- a/destination.go
+++ b/destination.go
@@ -3,9 +3,50 @@ package coremidi
 /*
 #cgo LDFLAGS: -framework CoreMIDI -framework CoreFoundation
 #include <CoreMIDI/CoreMIDI.h>
+#include <stdio.h>
+#include <unistd.h>
+
+static void MIDIInputProc(const MIDIPacketList *pktlist, void *readProcRefCon,  void *srcConnRefCon)
+{
+  MIDIPacket *packet = (MIDIPacket *)&(pktlist->packet[0]);
+  UInt32 packetCount = pktlist->numPackets;
+  int i, j, n;
+  Byte *data;
+
+  for (i = 0; i < packetCount; i++) {
+    data = calloc(sizeof(Byte), packet->length + 1);
+    *data = packet->length;
+
+    for (j = 0; j < packet->length; j++) {
+      *(data + j + 1) = *(packet->data + j);
+    }
+
+    // http://man7.org/linux/man-pages/man7/pipe.7.html
+    //
+    // POSIX.1-2001 says that write(2)s of less than PIPE_BUF bytes must be
+    // atomic: the output data is written to the pipe as a contiguous sequence.
+    //
+    // POSIX.1-2001 requires PIPE_BUF to be at least 512 bytes.
+    n = write(*(int *)srcConnRefCon, data, packet->length + 1);
+    packet = MIDIPacketNext(packet);
+    free(data);
+  }
+}
+
+typedef void (*midi_input_proc)(const MIDIPacketList *pktlist, void *readProcRefCon, void *srcConnRefCon);
+
+static midi_input_proc getProc()
+{
+  return *MIDIInputProc;
+}
+
 */
 import "C"
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"unsafe"
+)
 
 type Destination struct {
 	endpoint C.MIDIEndpointRef
@@ -29,6 +70,28 @@ func AllDestinations() (destinations []Destination, err error) {
 			destination,
 			&Object{C.MIDIObjectRef(destination)}}
 	}
+
+	return
+}
+
+func NewDestination(client Client, name string, readProc ReadProc) (destination Destination, err error) {
+	var endpointRef C.MIDIEndpointRef
+
+	stringToCFString(name, func(cfName C.CFStringRef) {
+		osStatus := C.MIDIDestinationCreate(
+			client.client,
+			cfName,
+			(C.MIDIReadProc)(C.getProc()),
+			unsafe.Pointer(uintptr(0)),
+			&endpointRef,
+		)
+
+		if osStatus != C.noErr {
+			err = errors.New(fmt.Sprintf("%d: failed to create a destination", int(osStatus)))
+		} else {
+			destination = Destination{endpointRef, &Object{C.MIDIObjectRef(endpointRef)}}
+		}
+	})
 
 	return
 }


### PR DESCRIPTION
So, here's what I'm trying to do.
There's this software that only takes input from one MIDI instrument at a time.
So I'm trying to create a Destination that merges input from all sources and forwards this so I can use it as a source for this software.
Here's what I have so far:

```go
package main

import (
	coremidi "github.com/youpy/go-coremidi"
)

func main() {
	client, err := coremidi.NewClient("a client")
	if err != nil {
		panic(err)
	}

	sources, err := coremidi.AllSources()
	if err != nil {
		panic(err)
	}

	mixerSource, err := coremidi.NewSource(client, "FM source")
	if err != nil {
		panic(err)
	}

	mixerDestination, err := coremidi.NewDestination(client, "FM destination", func(source coremidi.Source, value []byte) {
		err := coremidi.NewPacket(value).Received(&mixerSource)
		if err != nil {
			panic(err)
		}
		return
	})
	if err != nil {
		panic(err)
	}

	outPort, err := coremidi.NewOutputPort(client, "FM in")
	if err != nil {
		panic(err)
	}
	port, err := coremidi.NewInputPort(client, "test", func(source coremidi.Source, value []byte) {
		coremidi.NewPacket(value).Send(&outPort, &mixerDestination)
		return
	})

	if err != nil {
		panic(err)
	}

	for _, source := range sources {
		if source.Name() != mixerSource.Name() {
			func(source coremidi.Source) {
				port.Connect(source)
			}(source)
		}
	}

	ch := make(chan int)
	<-ch
}
```

The code currently exits with `signal: segmentation fault`.
Help please.