### PR TITLE
Add CoreMIDI notifications and fix stale device list

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,48 @@ func main() {
 }
 ```
 
+### Handle Device Notifications
+
+CoreMIDI delivers device notifications via a CFRunLoop on the same OS thread
+that created the client. If the run loop is not running, device changes may
+not be delivered and polling APIs can return stale results.
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+
+	"github.com/youpy/go-coremidi"
+)
+
+func main() {
+	runtime.LockOSThread()
+
+	loop := coremidi.CurrentRunLoop()
+	client, err := coremidi.NewClientWithNotification("notify-client", func(notification coremidi.Notification) {
+		fmt.Printf("notification: %s\n", notification.MessageID)
+	})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer client.Close()
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt)
+	go func() {
+		<-stop
+		loop.Stop()
+	}()
+
+	loop.Run()
+}
+```
+
 ## Documents
 
 * http://godoc.org/github.com/youpy/go-coremidi

--- a/client.go
+++ b/client.go
@@ -4,15 +4,69 @@ package coremidi
 #cgo LDFLAGS: -framework CoreMIDI -framework CoreFoundation -framework CoreServices
 #include <CoreMIDI/CoreMIDI.h>
 #include <CoreServices/CoreServices.h>
+#include <stdint.h>
+
+extern void midiNotifyCallback(uintptr_t handle, MIDINotification *message);
+extern void midiNotifyProc(const MIDINotification *message, void *refCon);
 */
 import "C"
 
-import "fmt"
+import (
+	"fmt"
+	"runtime/cgo"
+	"unsafe"
+)
 
 type Client struct {
-	client C.MIDIClientRef
+	client       C.MIDIClientRef
+	notifyHandle cgo.Handle
+	hasNotify    bool
 }
 
+type MIDINotificationMessageID int32
+
+const (
+	MIDIMsgSetupChanged         MIDINotificationMessageID = 1
+	MIDIMsgObjectAdded          MIDINotificationMessageID = 2
+	MIDIMsgObjectRemoved        MIDINotificationMessageID = 3
+	MIDIMsgPropertyChanged      MIDINotificationMessageID = 4
+	MIDIMsgThruConnectionsChanged MIDINotificationMessageID = 5
+	MIDIMsgSerialPortOwnerChanged MIDINotificationMessageID = 6
+	MIDIMsgIOError              MIDINotificationMessageID = 7
+)
+
+func (id MIDINotificationMessageID) String() string {
+	switch id {
+	case MIDIMsgSetupChanged:
+		return "SetupChanged"
+	case MIDIMsgObjectAdded:
+		return "ObjectAdded"
+	case MIDIMsgObjectRemoved:
+		return "ObjectRemoved"
+	case MIDIMsgPropertyChanged:
+		return "PropertyChanged"
+	case MIDIMsgThruConnectionsChanged:
+		return "ThruConnectionsChanged"
+	case MIDIMsgSerialPortOwnerChanged:
+		return "SerialPortOwnerChanged"
+	case MIDIMsgIOError:
+		return "IOError"
+	default:
+		return "Unknown"
+	}
+}
+
+type Notification struct {
+	MessageID MIDINotificationMessageID
+}
+
+// TODO: Expose structured notification payloads (e.g. add/remove/property change).
+type NotifyFunc func(notification Notification)
+
+// NewClient creates a CoreMIDI client without a notify callback.
+// A CFRunLoop is not required to call polling APIs, but without a running loop
+// on the client's thread, CoreMIDI may not deliver device list updates, so
+// polling can return stale results in long-running processes.
 func NewClient(name string) (client Client, err error) {
 	var clientRef C.MIDIClientRef
 
@@ -22,9 +76,74 @@ func NewClient(name string) (client Client, err error) {
 		if osStatus != C.noErr {
 			err = fmt.Errorf("%d: failed to create a client", int(osStatus))
 		} else {
-			client = Client{clientRef}
+			client = Client{client: clientRef}
 		}
 	})
 
 	return
+}
+
+// NewClientWithNotification creates a CoreMIDI client and registers a notify callback.
+// CoreMIDI delivers device updates via a CFRunLoop on the same OS thread that created
+// the client. That loop must be running for the system's device list to update at all
+// (including for polling APIs), not just for notifications to fire.
+// See: https://stackoverflow.com/questions/19002598/midiclientcreate-notifyproc-not-getting-called
+func NewClientWithNotification(name string, notify NotifyFunc) (client Client, err error) {
+	var clientRef C.MIDIClientRef
+	handle := cgo.NewHandle(notify)
+	refCon := unsafe.Pointer(handle)
+
+	stringToCFString(name, func(cfName C.CFStringRef) {
+		osStatus := C.MIDIClientCreate(cfName, (C.MIDINotifyProc)(C.midiNotifyProc), refCon, &clientRef)
+
+		if osStatus != C.noErr {
+			err = fmt.Errorf("%d: failed to create a client", int(osStatus))
+		} else {
+			client = Client{client: clientRef, notifyHandle: handle, hasNotify: true}
+		}
+	})
+
+	if err != nil {
+		handle.Delete()
+	}
+
+	return
+}
+
+func (client *Client) Close() error {
+	if client.client == 0 {
+		return nil
+	}
+
+	osStatus := C.MIDIClientDispose(client.client)
+	client.client = 0
+
+	if client.hasNotify {
+		client.notifyHandle.Delete()
+		client.hasNotify = false
+	}
+
+	if osStatus != C.noErr {
+		return fmt.Errorf("%d: failed to dispose client", int(osStatus))
+	}
+
+	return nil
+}
+
+//export midiNotifyCallback
+func midiNotifyCallback(handle C.uintptr_t, message *C.MIDINotification) {
+	var messageID MIDINotificationMessageID
+	if message != nil {
+		messageID = MIDINotificationMessageID(message.messageID)
+	}
+	if handle == 0 {
+		return
+	}
+
+	h := cgo.Handle(handle)
+	if notify, ok := h.Value().(NotifyFunc); ok && notify != nil {
+		notify(Notification{
+			MessageID: messageID,
+		})
+	}
 }

--- a/client_notify.c
+++ b/client_notify.c
@@ -1,0 +1,8 @@
+#include <CoreMIDI/CoreMIDI.h>
+#include <stdint.h>
+
+extern void midiNotifyCallback(uintptr_t handle, MIDINotification *message);
+
+void midiNotifyProc(const MIDINotification *message, void *refCon) {
+  midiNotifyCallback((uintptr_t)refCon, (MIDINotification *)message);
+}

--- a/client_test.go
+++ b/client_test.go
@@ -9,3 +9,29 @@ func TestNewClient(t *testing.T) {
 		t.Fatalf("invalid client")
 	}
 }
+
+func TestNewClientWithNotification(t *testing.T) {
+	client, err := NewClientWithNotification("test", func(notification Notification) {})
+	if err != nil {
+		t.Fatalf("invalid notify client")
+	}
+
+	if err := client.Close(); err != nil {
+		t.Fatalf("failed to close notify client")
+	}
+}
+
+func TestClientCloseIdempotent(t *testing.T) {
+	client, err := NewClient("test")
+	if err != nil {
+		t.Fatalf("invalid client")
+	}
+
+	if err := client.Close(); err != nil {
+		t.Fatalf("failed to close client")
+	}
+
+	if err := client.Close(); err != nil {
+		t.Fatalf("failed to close client twice")
+	}
+}

--- a/examples/notifications/notifications.go
+++ b/examples/notifications/notifications.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+
+	coremidi "github.com/youpy/go-coremidi"
+)
+
+func main() {
+	runtime.LockOSThread()
+
+	loop := coremidi.CurrentRunLoop()
+	client, err := coremidi.NewClientWithNotification("notify-client", func(notification coremidi.Notification) {
+		fmt.Printf("notification: %s\n", notification.MessageID)
+	})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer client.Close()
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt)
+	go func() {
+		<-stop
+		loop.Stop()
+	}()
+
+	loop.Run()
+}

--- a/notification_test.go
+++ b/notification_test.go
@@ -1,0 +1,25 @@
+package coremidi
+
+import "testing"
+
+func TestNotificationMessageIDString(t *testing.T) {
+	cases := []struct {
+		id       MIDINotificationMessageID
+		expected string
+	}{
+		{MIDIMsgSetupChanged, "SetupChanged"},
+		{MIDIMsgObjectAdded, "ObjectAdded"},
+		{MIDIMsgObjectRemoved, "ObjectRemoved"},
+		{MIDIMsgPropertyChanged, "PropertyChanged"},
+		{MIDIMsgThruConnectionsChanged, "ThruConnectionsChanged"},
+		{MIDIMsgSerialPortOwnerChanged, "SerialPortOwnerChanged"},
+		{MIDIMsgIOError, "IOError"},
+		{MIDINotificationMessageID(999), "Unknown"},
+	}
+
+	for _, testCase := range cases {
+		if got := testCase.id.String(); got != testCase.expected {
+			t.Fatalf("unexpected string for %d: %s", testCase.id, got)
+		}
+	}
+}

--- a/object.go
+++ b/object.go
@@ -37,8 +37,16 @@ func (object Object) Name() string {
 	return object.getStringProperty(C.kMIDIPropertyName)
 }
 
+func (object Object) DisplayName() string {
+	return object.getStringProperty(C.kMIDIPropertyDisplayName)
+}
+
 func (object Object) Manufacturer() string {
 	return object.getStringProperty(C.kMIDIPropertyManufacturer)
+}
+
+func (object Object) UniqueID() int32 {
+	return object.getIntProperty(C.kMIDIPropertyUniqueID)
 }
 
 func (object Object) getStringProperty(key C.CFStringRef) (propValue string) {
@@ -58,4 +66,15 @@ func (object Object) getStringProperty(key C.CFStringRef) (propValue string) {
 	propValue = C.GoString(value)
 
 	return
+}
+
+func (object Object) getIntProperty(key C.CFStringRef) int32 {
+	var result C.SInt32
+
+	osStatus := C.MIDIObjectGetIntegerProperty(object.object, key, &result)
+	if osStatus != C.noErr {
+		return 0
+	}
+
+	return int32(result)
 }

--- a/runloop.go
+++ b/runloop.go
@@ -1,0 +1,79 @@
+package coremidi
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation
+#include <CoreFoundation/CoreFoundation.h>
+
+static CFRunLoopRef currentRunLoop() {
+  return CFRunLoopGetCurrent();
+}
+
+static void retainRunLoop(CFRunLoopRef loop) {
+  if (loop != NULL) {
+    CFRetain(loop);
+  }
+}
+
+static void releaseRunLoop(CFRunLoopRef loop) {
+  if (loop != NULL) {
+    CFRelease(loop);
+  }
+}
+
+static void runLoopRun() {
+  CFRunLoopRun();
+}
+
+static void runLoopStop(CFRunLoopRef loop) {
+  if (loop != NULL) {
+    CFRunLoopStop(loop);
+    CFRunLoopWakeUp(loop);
+  }
+}
+*/
+import "C"
+
+import "runtime"
+
+type RunLoop struct {
+	loop C.CFRunLoopRef
+}
+
+// CurrentRunLoop returns the current thread's CFRunLoop.
+func CurrentRunLoop() *RunLoop {
+	loop := C.currentRunLoop()
+	C.retainRunLoop(loop)
+	return &RunLoop{loop: loop}
+}
+
+// Run starts the CFRunLoop on the current thread.
+func (r *RunLoop) Run() {
+	if r == nil || r.loop == 0 {
+		return
+	}
+	C.runLoopRun()
+}
+
+// StartRunLoop starts a CFRunLoop on a locked OS thread.
+// The returned RunLoop can be stopped with Stop().
+func StartRunLoop() *RunLoop {
+	ch := make(chan C.CFRunLoopRef, 1)
+	go func() {
+		runtime.LockOSThread()
+		loop := C.currentRunLoop()
+		C.retainRunLoop(loop)
+		ch <- loop
+		C.runLoopRun()
+		C.releaseRunLoop(loop)
+	}()
+	loop := <-ch
+	return &RunLoop{loop: loop}
+}
+
+// Stop stops the CFRunLoop.
+func (r *RunLoop) Stop() {
+	if r == nil || r.loop == 0 {
+		return
+	}
+	C.runLoopStop(r.loop)
+}

--- a/runloop_test.go
+++ b/runloop_test.go
@@ -1,0 +1,23 @@
+package coremidi
+
+import "testing"
+
+func TestRunLoopStartStop(t *testing.T) {
+	loop := StartRunLoop()
+	if loop == nil || loop.loop == 0 {
+		t.Fatalf("expected valid run loop")
+	}
+	loop.Stop()
+}
+
+func TestCurrentRunLoop(t *testing.T) {
+	loop := CurrentRunLoop()
+	if loop == nil || loop.loop == 0 {
+		t.Fatalf("expected current run loop")
+	}
+}
+
+func TestRunLoopStopNil(t *testing.T) {
+	var loop *RunLoop
+	loop.Stop()
+}


### PR DESCRIPTION
Add notification-capable clients with message IDs, stringers, and a Close helper. Include run loop utilities and a notify C shim so device updates are delivered; without the run loop, CoreMIDI’s device list goes stale and polling won’t reflect hotplug changes. Expose display names and unique IDs to align with CoreMIDI metadata.